### PR TITLE
-adding possiblity to mark fields as "masked" 

### DIFF
--- a/gs-web-elasticsearch/src/main/java/mil/nga/giat/elasticsearch/ElasticAttributeProvider.java
+++ b/gs-web-elasticsearch/src/main/java/mil/nga/giat/elasticsearch/ElasticAttributeProvider.java
@@ -85,6 +85,12 @@ public class ElasticAttributeProvider extends GeoServerDataProvider<ElasticAttri
             "stored");
 
     /**
+     * If field is stored
+     */
+    protected static final Property<ElasticAttribute> MASKED = new BeanProperty<ElasticAttribute>("masked",
+            "masked");
+
+    /**
      * Build attribute provider
      * 
      * @param attributes list to use as source for provider
@@ -95,7 +101,7 @@ public class ElasticAttributeProvider extends GeoServerDataProvider<ElasticAttri
 
     @Override
     protected List<org.geoserver.web.wicket.GeoServerDataProvider.Property<ElasticAttribute>> getProperties() {
-        return Arrays.asList(USE, NAME, TYPE, DEFAULT_GEOMETRY, STORED, ANALYZED, SRID, DATE_FORMAT);
+        return Arrays.asList(USE, NAME, TYPE, DEFAULT_GEOMETRY, STORED, ANALYZED, SRID, DATE_FORMAT, MASKED);
     }
 
     @Override

--- a/gs-web-elasticsearch/src/main/java/mil/nga/giat/elasticsearch/ElasticConfigurationPage.html
+++ b/gs-web-elasticsearch/src/main/java/mil/nga/giat/elasticsearch/ElasticConfigurationPage.html
@@ -38,5 +38,9 @@
 	<wicket:fragment wicket:id="label">
 		<span wicket:id="label"></span>
 	</wicket:fragment>
+	<wicket:fragment wicket:id="checkboxMasked">
+		<input type="checkbox" wicket:id="masked"></input>
+	</wicket:fragment>
+
 </body>
 </html>

--- a/gs-web-elasticsearch/src/main/java/mil/nga/giat/elasticsearch/ElasticConfigurationPage.java
+++ b/gs-web-elasticsearch/src/main/java/mil/nga/giat/elasticsearch/ElasticConfigurationPage.java
@@ -328,6 +328,14 @@ public abstract class ElasticConfigurationPage extends Panel {
                         Fragment f = new Fragment(id, "empty", ElasticConfigurationPage.this);
                         return f;
                     }
+                } else if (property == ElasticAttributeProvider.MASKED) {
+                    Fragment f = new Fragment(id, "checkboxMasked",
+                            ElasticConfigurationPage.this);
+                    CheckBox checkBox = new CheckBox("masked", new PropertyModel<Boolean>(itemModel,
+                            "masked"));
+                    f.add(checkBox);
+                    return f;
+
                 }
                 return null;
             }

--- a/gs-web-elasticsearch/src/main/resources/GeoServerApplication.properties
+++ b/gs-web-elasticsearch/src/main/resources/GeoServerApplication.properties
@@ -10,6 +10,7 @@ ElasticConfigurationPage.th.srid = SRID
 ElasticConfigurationPage.th.defaultGeometry = Default Geometry
 ElasticConfigurationPage.th.dateFormat = Date Format
 ElasticConfigurationPage.th.analyzed = Analyzed
+ElasticConfigurationPage.th.checkboxMasked = Output hidden but searchable
 ElasticConfigurationPage.th.stored = Stored
 ElasticConfigurationPage.useAll = Use all
 ElasticConfigurationPage.useShortName = Short names

--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticAttribute.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticAttribute.java
@@ -16,12 +16,23 @@ import java.util.Objects;
  */
 public class ElasticAttribute implements Serializable {
 
+
+
     public enum ElasticGeometryType {
         GEO_POINT,
-        GEO_SHAPE
+        GEO_SHAPE;
+    }
+    private static final long serialVersionUID = 8839579461838862328L;
+
+    public boolean isMasked() {
+        return masked;
     }
 
-    private static final long serialVersionUID = 8839579461838862328L;
+    public void setMasked(boolean masked) {
+        this.masked = masked;
+    }
+
+    private boolean masked;
 
     private String name;
 
@@ -52,6 +63,7 @@ public class ElasticAttribute implements Serializable {
         this.defaultGeometry = false;
         this.useShortName = false;
         this.stored = false;
+        this.masked = false;
     }
 
     public ElasticAttribute(ElasticAttribute other) {
@@ -66,6 +78,7 @@ public class ElasticAttribute implements Serializable {
         this.geometryType = other.geometryType;
         this.analyzed = other.analyzed;
         this.stored = other.stored;
+        this.masked = other.masked;
     }
 
     public String getName() {
@@ -172,6 +185,7 @@ public class ElasticAttribute implements Serializable {
                 + ", defaultGeometry=" + defaultGeometry + ", srid=" + srid
                 + ", dateFormat=" + dateFormat + ", useShortName=" + useShortName + ""
                 + ", geometryType=" + geometryType + ", analyzed=" + analyzed
+                + ", masked=" + masked
                 + ", stored=" + stored + "]";
     }
 
@@ -198,6 +212,7 @@ public class ElasticAttribute implements Serializable {
             equal &= Objects.equals(geometryType, other.geometryType);
             equal &= Objects.equals(analyzed, other.analyzed);
             equal &= Objects.equals(stored, other.stored);
+            equal &= Objects.equals(masked, other.masked);
         }
         return equal;
     }

--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticDataStore.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticDataStore.java
@@ -80,7 +80,7 @@ public class ElasticDataStore extends ContentDataStore {
             String indexName, String searchIndices, String clusterName,
             boolean localNode, boolean storeData) {
 
-        LOGGER.fine("initializing data store " + searchHost + ":" + hostPort + "/" + indexName);
+        LOGGER.info("initializing data store " + searchHost + ":" + hostPort + "/" + indexName);
 
         this.indexName = indexName;
         
@@ -121,7 +121,7 @@ public class ElasticDataStore extends ContentDataStore {
                 .cluster()
                 .state(clusterStateRequest)
                 .actionGet().getState();
-        LOGGER.fine("obtained cluster state");
+        LOGGER.info(String.format("obtained cluster state %s", state));
 
         IndexMetaData metadata = state.metaData().index(indexName);
         if (metadata != null) {

--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticFeatureReader.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticFeatureReader.java
@@ -92,6 +92,9 @@ public class ElasticFeatureReader implements FeatureReader<SimpleFeatureType, Si
                 values = parserUtil.readField(source, sourceName);
             }
 
+            if ((boolean) type.getDescriptor(name).getUserData().get(ElasticLayerConfiguration.OUTPUT_MASKED)) {
+                values = null;
+            }
             if (values == null && name.equals("_id")) {
                 builder.set(name, hit.getId());
             } else if (values == null && name.equals("_index")) {

--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticFeatureTypeBuilder.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticFeatureTypeBuilder.java
@@ -7,10 +7,6 @@ package mil.nga.giat.data.elasticsearch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static mil.nga.giat.data.elasticsearch.ElasticLayerConfiguration.ANALYZED;
-import static mil.nga.giat.data.elasticsearch.ElasticLayerConfiguration.DATE_FORMAT;
-import static mil.nga.giat.data.elasticsearch.ElasticLayerConfiguration.FULL_NAME;
-import static mil.nga.giat.data.elasticsearch.ElasticLayerConfiguration.GEOMETRY_TYPE;
 import mil.nga.giat.data.elasticsearch.ElasticAttribute.ElasticGeometryType;
 
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
@@ -21,10 +17,11 @@ import org.opengis.feature.type.Name;
 
 import com.vividsolutions.jts.geom.Geometry;
 
+import static mil.nga.giat.data.elasticsearch.ElasticLayerConfiguration.*;
+
 /**
- * Builds a feature type based on the attributes defined in the 
+ * Builds a feature type based on the attributes defined in the
  * {@link ElasticLayerConfiguration}.
- *
  */
 public class ElasticFeatureTypeBuilder extends SimpleFeatureTypeBuilder {
 
@@ -60,7 +57,7 @@ public class ElasticFeatureTypeBuilder extends SimpleFeatureTypeBuilder {
                                 attributeBuilder.setBinding(attribute.getType());
                                 att = attributeBuilder.buildDescriptor(attributeName,
                                         attributeBuilder.buildGeometryType());
-                                
+
                                 final ElasticGeometryType geometryType = attribute.getGeometryType();
                                 att.getUserData().put(GEOMETRY_TYPE, geometryType);
                                 if (attribute.isDefaultGeometry() != null
@@ -75,7 +72,7 @@ public class ElasticFeatureTypeBuilder extends SimpleFeatureTypeBuilder {
                     } else {
                         attributeBuilder.setName(attributeName);
                         attributeBuilder.setBinding(attribute.getType());
-                        att = attributeBuilder.buildDescriptor(attributeName, 
+                        att = attributeBuilder.buildDescriptor(attributeName,
                                 attributeBuilder.buildType());
                     }
                     if (att != null && attribute.getDateFormat() != null) {
@@ -84,6 +81,7 @@ public class ElasticFeatureTypeBuilder extends SimpleFeatureTypeBuilder {
                     if (att != null) {
                         att.getUserData().put(FULL_NAME, attribute.getName());
                         att.getUserData().put(ANALYZED, attribute.getAnalyzed());
+                        att.getUserData().put(OUTPUT_MASKED, attribute.isMasked());
                         add(att);
                     }
                 }

--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticLayerConfiguration.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticLayerConfiguration.java
@@ -38,7 +38,12 @@ public class ElasticLayerConfiguration implements Serializable {
      * Key used in the feature type user data to indicate whether the field is analyzed.
      */
     public static final String ANALYZED = "analyzed";
-    
+
+    /**
+     * Key used in the feature type user data to indicate whether the field is analyzed.
+     */
+    public static final String OUTPUT_MASKED = "masked";
+
     /**
      * Key to identify the Elasticsearch layer configuration.
      */


### PR DESCRIPTION
- they are searchable via CQL filters, but the output is set to null in order to prevent accidental discovery of e.g. UUIDs that are private for just one customer. Feedback on this feature welcome before writing some tests.
