### PR TITLE
return saved instance instead of calling get to retreive instance

### DIFF
--- a/gt-elasticsearch-parent/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticFeatureReader.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/ElasticFeatureReader.java
@@ -61,7 +61,7 @@ public class ElasticFeatureReader implements FeatureReader<SimpleFeatureType, Si
 
     @Override
     public SimpleFeatureType getFeatureType() {
-        return state.getFeatureType();
+        return this.featureType;
     }
 
     @Override


### PR DESCRIPTION
mil.nga.giat.data.elasticsearch.ElasticFeatureReader creates an instance variable for the featureType. The method getFeatureType did not use this instance variable, instead getting the value by calling state.getFeatureType(). Updated the method to just use the stored instance variable

Fixes #18
