### PR TITLE
optional parameter gridStrategyEmptyCellValue

### DIFF
--- a/gs-web-elasticsearch/doc/index.rst
+++ b/gs-web-elasticsearch/doc/index.rst
@@ -316,7 +316,9 @@ Grid Strategy
      - yes
      - Extract raster value from nested aggregation results.
 
-``gridStrategyArgs``: Parameter used to specify an optional argument list for the grid strategy.
+``gridStrategyArgs``: (Optional) Parameter used to specify an optional argument list for the grid strategy.
+
+``gridStrategyEmptyCellValue``: (Optional) Parameter used to specify the value for empty grid cells. By default, empty grid cells are set to ``0``.
 
 Basic
 ~~~~~

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GeoHashGrid.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GeoHashGrid.java
@@ -6,6 +6,7 @@ package mil.nga.giat.process.elasticsearch;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -51,6 +52,8 @@ public abstract class GeoHashGrid {
 
     private List<Map<String, Object>> buckets;
 
+    private float emptyCellValue = 0;
+
     private float[][] grid;
 
     public GeoHashGrid initalize(ReferencedEnvelope srcEnvelope, SimpleFeatureCollection features) throws NoSuchAuthorityCodeException, TransformException, FactoryException {
@@ -79,6 +82,11 @@ public abstract class GeoHashGrid {
         final int numCol = (int) Math.round((envelope.getMaxX()-envelope.getMinX())/cellWidth+1);
         final int numRow = (int) Math.round((envelope.getMaxY()-envelope.getMinY())/cellHeight+1);
         grid = new float[numRow][numCol];
+
+        if (emptyCellValue != 0) {
+            for (float[] row: grid)
+                Arrays.fill(row, emptyCellValue);
+        }
 
         buckets.stream().forEach(bucket -> updateCell((String) bucket.get("key"), computeCellValue(bucket)));
 
@@ -199,6 +207,12 @@ public abstract class GeoHashGrid {
         //ignore params
     }
     
+    public void setEmptyCellValue(Float value) {
+        if (null != value) {
+            this.emptyCellValue = value;
+        }
+    }
+
     public double getCellWidth() {
         return cellWidth;
     }

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GeoHashGridProcess.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GeoHashGridProcess.java
@@ -48,6 +48,7 @@ public class GeoHashGridProcess implements VectorProcess {
             @DescribeParameter(name = "pixelsPerCell", description = "Resolution used for upsampling (in pixels). Default = 1", defaultValue="1", min = 1) Integer argPixelsPerCell,
             @DescribeParameter(name = "gridStrategy", description = "GeoHash grid strategy", defaultValue="Basic", min = 1) String gridStrategy,
             @DescribeParameter(name = "gridStrategyArgs", description = "grid strategy arguments", min = 0) List<String> gridStrategyArgs,
+            @DescribeParameter(name = "gridStrategyEmptyCellValue", description = "grid strategy empty cell value", min = 0) Float gridStrategyEmptyCellValue,
 
             // output image parameters
             @DescribeParameter(name = "outputBBOX", description = "Bounding box of the output") ReferencedEnvelope argOutputEnv,
@@ -60,6 +61,7 @@ public class GeoHashGridProcess implements VectorProcess {
             // construct and populate grid
             final GeoHashGrid geoHashGrid = Strategy.valueOf(gridStrategy.toUpperCase()).createNewInstance();
             geoHashGrid.setParams(gridStrategyArgs);
+            geoHashGrid.setEmptyCellValue(gridStrategyEmptyCellValue);
             geoHashGrid.initalize(argOutputEnv, obsFeatures);
             // convert to grid coverage
             final GridCoverage2D nativeCoverage = geoHashGrid.toGridCoverage2D();

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/GeoHashGridProcessTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/GeoHashGridProcessTest.java
@@ -52,9 +52,10 @@ public class GeoHashGridProcessTest {
         int pixelsPerCell = 1;
         String strategy = "Basic";
         List<String> strategyArgs = null;
+        Float emptyCellValue = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -67,9 +68,10 @@ public class GeoHashGridProcessTest {
         int pixelsPerCell = 1;
         String strategy = "Basic";
         List<String> strategyArgs = null;
+        Float emptyCellValue = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -82,9 +84,10 @@ public class GeoHashGridProcessTest {
         int pixelsPerCell = 1;
         String strategy = "Basic";
         List<String> strategyArgs = null;
+        Float emptyCellValue = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -97,9 +100,10 @@ public class GeoHashGridProcessTest {
         int pixelsPerCell = 1;
         String strategy = "Basic";
         List<String> strategyArgs = null;
+        Float emptyCellValue = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
     }
 

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/GeoHashGridTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/GeoHashGridTest.java
@@ -93,6 +93,33 @@ public class GeoHashGridTest {
     }
 
     @Test
+    public void testGeoHashGrid_emptyCellValue() throws Exception {
+        float emptyCellValue = -1.0f;
+        features = new DefaultFeatureCollection();
+        ReferencedEnvelope envelope = new ReferencedEnvelope(-180,180,-90,90,CRS.decode("EPSG:4326"));
+        geohashGrid.setEmptyCellValue(emptyCellValue);
+        geohashGrid.initalize(envelope, features);
+        IntStream.range(0, geohashGrid.getGrid().length).forEach(row-> {
+            IntStream.range(0, geohashGrid.getGrid()[row].length).forEach(column-> {
+              assertEquals(emptyCellValue, geohashGrid.getGrid()[row][column], 0.0);
+            });
+        });
+    }
+
+    @Test
+    public void testGeoHashGrid_nullEmptyCellValue() throws Exception {
+        features = new DefaultFeatureCollection();
+        ReferencedEnvelope envelope = new ReferencedEnvelope(-180,180,-90,90,CRS.decode("EPSG:4326"));
+        geohashGrid.setEmptyCellValue(null);
+        geohashGrid.initalize(envelope, features);
+        IntStream.range(0, geohashGrid.getGrid().length).forEach(row-> {
+            IntStream.range(0, geohashGrid.getGrid()[row].length).forEach(column-> {
+              assertEquals(0.0, geohashGrid.getGrid()[row][column], 0.0);
+            });
+        });
+    }
+
+    @Test
     public void testGeoHashGridWithNoAggregations() throws Exception {
         features = TestUtil.createAggregationFeatures(ImmutableList.of(
                 ImmutableMap.of("aString", UUID.randomUUID().toString())


### PR DESCRIPTION
There could be instances where a raster value of ``0`` has multiple meanings. 
* empty cell
* raster value extracted from geohashgrid bucket

To avoid this ambiguity, there needs to be a mechanism to specify empty cell values.

This pull request adds an optional parameter ``gridStrategyEmptyCellValue`` to allow users to set the empty cell value.