### PR TITLE
fixes #33

### DIFF
--- a/gt-elasticsearch-parent/gt-elasticsearch-core/src/main/java/mil/nga/giat/data/elasticsearch/ElasticCompat5.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-core/src/main/java/mil/nga/giat/data/elasticsearch/ElasticCompat5.java
@@ -85,14 +85,12 @@ public class ElasticCompat5 implements ElasticCompat {
 
     @Override
     public boolean isAnalyzed(Map<String, Object> map) {
+        boolean analyzed = false;
         Object value = map.get("type");
-        if (value != null && Map.class.isAssignableFrom(value.getClass())) {
-            //map is not property map
-            return false;
-        } else {
-            final String type = (String) map.get("type");
-            return type != null && type.equals("text");
+        if (value != null && value instanceof String && ((String) value).equals("text")) {
+            analyzed = true;
         }
+        return analyzed;
     }
 
     @Override

--- a/gt-elasticsearch-parent/gt-elasticsearch-core/src/main/java/mil/nga/giat/data/elasticsearch/ElasticCompat5.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-core/src/main/java/mil/nga/giat/data/elasticsearch/ElasticCompat5.java
@@ -85,8 +85,14 @@ public class ElasticCompat5 implements ElasticCompat {
 
     @Override
     public boolean isAnalyzed(Map<String, Object> map) {
-        final String index = (String) map.get("index");
-        return index != null && index.equals("analyzed");
+        Object value = map.get("type");
+        if (value != null && Map.class.isAssignableFrom(value.getClass())) {
+            //map is not property map
+            return false;
+        } else {
+            final String type = (String) map.get("type");
+            return type != null && type.equals("text");
+        }
     }
 
     @Override

--- a/gt-elasticsearch-parent/gt-elasticsearch-core/src/test/java/mil/nga/giat/data/elasticsearch/ElasticCompatTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-core/src/test/java/mil/nga/giat/data/elasticsearch/ElasticCompatTest.java
@@ -49,10 +49,12 @@ public class ElasticCompatTest {
         assertEquals(1, point.getLon(), 1e-4);
         assertEquals(86461000, compat.parseDateTime("1970-01-02 00:01:01", "yyyy-mm-dd HH:mm:ss").getTime());
         assertFalse(compat.isAnalyzed(new HashMap<>()));
-        assertFalse(compat.isAnalyzed(ImmutableMap.of("index", "not_analyzed")));
-        assertFalse(compat.isAnalyzed(ImmutableMap.of("index", "not_valid")));
-        assertTrue(compat.isAnalyzed(ImmutableMap.of("index", "analyzed")));
+        assertFalse(compat.isAnalyzed(ImmutableMap.of("type", "keyword")));
+        assertFalse(compat.isAnalyzed(ImmutableMap.of("type", ImmutableMap.of("type", "keyword"))));
+        assertFalse(compat.isAnalyzed(ImmutableMap.of("type", "not_valid")));
+        assertTrue(compat.isAnalyzed(ImmutableMap.of("type", "text")));
     }
+    
 
     @Test(expected=IOException.class)
     public void testCreateClient() throws IOException {


### PR DESCRIPTION
Updates `mil.nga.giat.data.elasticsearch.ElasticCompat5 isAnalyzed` method to support new 5.x conventions.

Elasticsearch 5.x changed how analyzed fields are defined. In 2.x, the field `index` was set to `analyzed` or `not_ analyzed`. In 5.x, the field `type` is set to `keyword` or `text`.  

The method now has to check to see if the value pulled from the map is itself a map. The reason for this is that there is a naming collision for the key `type`. At the top level, it is the key for a property. At the property level, it is a key for the field type. `mil.nga.giat.data.elasticsearch.ElasticDataStore ` Line 312 causes the problems that are avoided with the extra if statement
```
else if (key.equals("type") && !value.equals("nested")) {
    add(elasticAttributes, propertyKey, (String) value, map, nested);
}
```