### PR TITLE
gridStrategyScale

### DIFF
--- a/gs-web-elasticsearch/doc/index.rst
+++ b/gs-web-elasticsearch/doc/index.rst
@@ -320,6 +320,9 @@ Grid Strategy
 
 ``gridStrategyEmptyCellValue``: (Optional) Parameter used to specify the value for empty grid cells. By default, empty grid cells are set to ``0``.
 
+``gridStrategyScale``: (Optional) Parameter used to specify a scale applied to all raster values. Each tile request is scaled according to the min and max values for that tile. It is best to use a non-tited layer with this parameter to avoid confusing results.
+
+
 Basic
 ~~~~~
 Raster value is geohashgrid bucket ``doc_count``.

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GridCell.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GridCell.java
@@ -1,3 +1,7 @@
+/**
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file.
+ */
 package mil.nga.giat.process.elasticsearch;
 
 public class GridCell {

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GridCell.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/GridCell.java
@@ -1,0 +1,19 @@
+package mil.nga.giat.process.elasticsearch;
+
+public class GridCell {
+    private final String geohash;
+    private final Number value;
+    
+    public GridCell(String geohash, Number value) {
+        this.geohash = geohash;
+        this.value = value;
+    }
+    
+    public String getGeohash() {
+        return geohash;
+    }
+    
+    public Number getValue() {
+        return value;
+    }
+}

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
@@ -10,7 +10,7 @@ public class RasterScale {
     private float dataMax;
     private float scaleMin;
     private float scaleMax;
-    
+
     public RasterScale(List<Float> range) {
         if (null != range && range.size() == 1) {
             scaleSet = true;
@@ -32,11 +32,13 @@ public class RasterScale {
     }
     
     public float scaleValue(float value) {
-        float scaledValue = value;
-        if (scaleSet) {
+        if (!scaleSet) {
+            return value;
+        } else if (dataMax == dataMin) {
+            return scaleMax;
+        } else {
             return ((scaleMax - scaleMin) * (value - dataMin) / (dataMax - dataMin)) + scaleMin;
         }
-        return scaledValue;
     }
     
     public void prepareScale(float value) {

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
@@ -1,0 +1,78 @@
+package mil.nga.giat.process.elasticsearch;
+
+import java.util.List;
+
+public class RasterScale {
+
+    private boolean isMinMaxInitialized = false;
+    private boolean scaleSet = false;
+    private float dataMin;
+    private float dataMax;
+    private float scaleMin;
+    private float scaleMax;
+    
+    public RasterScale(List<Float> scale) {
+        if (null != scale && scale.size() == 1) {
+            scaleSet = true;
+            scaleMin = 0;
+            scaleMax = scale.get(0);
+        } else if (null != scale && scale.size() == 2) {
+            scaleSet = true;
+            scaleMax = scale.get(0);
+            scaleMin = scale.get(1);
+            if (scaleMin > scaleMax) {
+                scaleMax = scale.get(1);
+                scaleMin = scale.get(0);
+            }
+        }
+        
+        if (scaleSet && scaleMax == scaleMin) {
+            throw new IllegalArgumentException();
+        }
+    }
+    
+    public float scaleValue(float value) {
+        float scaledValue = value;
+        if (scaleSet) {
+            return ((scaleMax - scaleMin) * (value - dataMin) / (dataMax - dataMin)) + scaleMin;
+        }
+        return scaledValue;
+    }
+    
+    public void prepareScale(float value) {
+        if (!scaleSet) return; 
+
+        if (isMinMaxInitialized) {
+            if (value < dataMin) {
+                dataMin = value;
+            }
+            if (value > dataMax) {
+                dataMax = value;
+            }
+        } else {
+            dataMin = value;
+            dataMax = value;
+            isMinMaxInitialized = true;
+        }
+    }
+    
+    public boolean isScaleSet() {
+        return scaleSet;
+    }
+
+    public float getDataMin() {
+        return dataMin;
+    }
+
+    public float getDataMax() {
+        return dataMax;
+    }
+
+    public float getScaleMin() {
+        return scaleMin;
+    }
+
+    public float getScaleMax() {
+        return scaleMax;
+    }
+}

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
@@ -1,3 +1,7 @@
+/**
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file.
+ */
 package mil.nga.giat.process.elasticsearch;
 
 import java.util.List;

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/main/java/mil/nga/giat/process/elasticsearch/RasterScale.java
@@ -11,18 +11,18 @@ public class RasterScale {
     private float scaleMin;
     private float scaleMax;
     
-    public RasterScale(List<Float> scale) {
-        if (null != scale && scale.size() == 1) {
+    public RasterScale(List<Float> range) {
+        if (null != range && range.size() == 1) {
             scaleSet = true;
             scaleMin = 0;
-            scaleMax = scale.get(0);
-        } else if (null != scale && scale.size() == 2) {
+            scaleMax = range.get(0);
+        } else if (null != range && range.size() == 2) {
             scaleSet = true;
-            scaleMax = scale.get(0);
-            scaleMin = scale.get(1);
+            scaleMax = range.get(0);
+            scaleMin = range.get(1);
             if (scaleMin > scaleMax) {
-                scaleMax = scale.get(1);
-                scaleMin = scale.get(0);
+                scaleMax = range.get(1);
+                scaleMin = range.get(0);
             }
         }
         

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/GeoHashGridProcessTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/GeoHashGridProcessTest.java
@@ -53,9 +53,10 @@ public class GeoHashGridProcessTest {
         String strategy = "Basic";
         List<String> strategyArgs = null;
         Float emptyCellValue = null;
+        List<String> scale = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, scale, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -69,9 +70,10 @@ public class GeoHashGridProcessTest {
         String strategy = "Basic";
         List<String> strategyArgs = null;
         Float emptyCellValue = null;
+        List<String> scale = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, scale, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -85,9 +87,10 @@ public class GeoHashGridProcessTest {
         String strategy = "Basic";
         List<String> strategyArgs = null;
         Float emptyCellValue = null;
+        List<String> scale = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, scale, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
         checkEdge(coverage, envelope, fineDelta);
     }
@@ -101,9 +104,10 @@ public class GeoHashGridProcessTest {
         String strategy = "Basic";
         List<String> strategyArgs = null;
         Float emptyCellValue = null;
+        List<String> scale = null;
 
         GeoHashGridProcess process = new GeoHashGridProcess();
-        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, envelope, width, height, null);
+        GridCoverage2D coverage = process.execute(features, pixelsPerCell, strategy, strategyArgs, emptyCellValue, scale, envelope, width, height, null);
         checkInternal(coverage, fineDelta);
     }
 

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/RasterScaleTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/RasterScaleTest.java
@@ -20,18 +20,18 @@ public class RasterScaleTest {
     }
     
     @Test
-    public void testRasterScale_emptyScale() throws Exception {
-        List<Float> list = new ArrayList<Float>();
-        RasterScale scale = new RasterScale(list);
+    public void testRasterScale_emptyRange() throws Exception {
+        List<Float> range = new ArrayList<Float>();
+        RasterScale scale = new RasterScale(range);
         assertFalse(scale.isScaleSet());
     }
     
     @Test
     public void testRasterScale_maxProvided() throws Exception {
         float scaleMax = 10.0f;
-        List<Float> list = new ArrayList<Float>();
-        list.add(scaleMax);
-        RasterScale scale = new RasterScale(list);
+        List<Float> range = new ArrayList<Float>();
+        range.add(scaleMax);
+        RasterScale scale = new RasterScale(range);
         assertTrue(scale.isScaleSet());
         assertEquals(0, scale.getScaleMin(), 0.0);
         assertEquals(scaleMax, scale.getScaleMax(), 0.0);
@@ -41,10 +41,10 @@ public class RasterScaleTest {
     public void testRasterScale_minMaxProvided() throws Exception {
         float scaleMax = 10.0f;
         float scaleMin = 1.0f;
-        List<Float> list = new ArrayList<Float>();
-        list.add(scaleMin);
-        list.add(scaleMax);
-        RasterScale scale = new RasterScale(list);
+        List<Float> range = new ArrayList<Float>();
+        range.add(scaleMin);
+        range.add(scaleMax);
+        RasterScale scale = new RasterScale(range);
         assertTrue(scale.isScaleSet());
         assertEquals(scaleMin, scale.getScaleMin(), 0.0);
         assertEquals(scaleMax, scale.getScaleMax(), 0.0);
@@ -54,25 +54,36 @@ public class RasterScaleTest {
     public void testRasterScale_minMaxSame() throws Exception {
         float scaleMax = 10.0f;
         float scaleMin = scaleMax;
-        List<Float> list = new ArrayList<Float>();
-        list.add(scaleMin);
-        list.add(scaleMax);
-        new RasterScale(list);
+        List<Float> range = new ArrayList<Float>();
+        range.add(scaleMin);
+        range.add(scaleMax);
+        new RasterScale(range);
     }
     
     @Test
     public void testRasterScale_scaleValue() throws Exception {
         float scaleMax = 10.0f;
         float scaleMin = 0.0f;
-        List<Float> list = new ArrayList<Float>();
-        list.add(scaleMin);
-        list.add(scaleMax);
-        RasterScale scale = new RasterScale(list);
+        List<Float> range = new ArrayList<Float>();
+        range.add(scaleMin);
+        range.add(scaleMax);
+        RasterScale scale = new RasterScale(range);
         scale.prepareScale(30);
         scale.prepareScale(20);
         scale.prepareScale(10);
         assertEquals(10, scale.scaleValue(30), 0.0);
         assertEquals(5, scale.scaleValue(20), 0.0);
         assertEquals(0, scale.scaleValue(10), 0.0);
+    }
+    
+    @Test
+    public void testRasterScale_scaleValue_emptyScale() throws Exception {
+        RasterScale scale = new RasterScale(null);
+        scale.prepareScale(30);
+        scale.prepareScale(20);
+        scale.prepareScale(10);
+        assertEquals(30, scale.scaleValue(30), 0.0);
+        assertEquals(20, scale.scaleValue(20), 0.0);
+        assertEquals(10, scale.scaleValue(10), 0.0);
     }
 }

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/RasterScaleTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/RasterScaleTest.java
@@ -1,0 +1,78 @@
+/**
+ * This file is hereby placed into the Public Domain. This means anyone is
+ * free to do whatever they wish with this file.
+ */
+package mil.nga.giat.process.elasticsearch;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class RasterScaleTest {
+
+    @Test
+    public void testRasterScale_noScale() throws Exception {
+        RasterScale scale = new RasterScale(null);
+        assertFalse(scale.isScaleSet());
+    }
+    
+    @Test
+    public void testRasterScale_emptyScale() throws Exception {
+        List<Float> list = new ArrayList<Float>();
+        RasterScale scale = new RasterScale(list);
+        assertFalse(scale.isScaleSet());
+    }
+    
+    @Test
+    public void testRasterScale_maxProvided() throws Exception {
+        float scaleMax = 10.0f;
+        List<Float> list = new ArrayList<Float>();
+        list.add(scaleMax);
+        RasterScale scale = new RasterScale(list);
+        assertTrue(scale.isScaleSet());
+        assertEquals(0, scale.getScaleMin(), 0.0);
+        assertEquals(scaleMax, scale.getScaleMax(), 0.0);
+    }
+    
+    @Test
+    public void testRasterScale_minMaxProvided() throws Exception {
+        float scaleMax = 10.0f;
+        float scaleMin = 1.0f;
+        List<Float> list = new ArrayList<Float>();
+        list.add(scaleMin);
+        list.add(scaleMax);
+        RasterScale scale = new RasterScale(list);
+        assertTrue(scale.isScaleSet());
+        assertEquals(scaleMin, scale.getScaleMin(), 0.0);
+        assertEquals(scaleMax, scale.getScaleMax(), 0.0);
+    }
+    
+    @Test(expected=IllegalArgumentException.class)
+    public void testRasterScale_minMaxSame() throws Exception {
+        float scaleMax = 10.0f;
+        float scaleMin = scaleMax;
+        List<Float> list = new ArrayList<Float>();
+        list.add(scaleMin);
+        list.add(scaleMax);
+        new RasterScale(list);
+    }
+    
+    @Test
+    public void testRasterScale_scaleValue() throws Exception {
+        float scaleMax = 10.0f;
+        float scaleMin = 0.0f;
+        List<Float> list = new ArrayList<Float>();
+        list.add(scaleMin);
+        list.add(scaleMax);
+        RasterScale scale = new RasterScale(list);
+        scale.prepareScale(30);
+        scale.prepareScale(20);
+        scale.prepareScale(10);
+        assertEquals(10, scale.scaleValue(30), 0.0);
+        assertEquals(5, scale.scaleValue(20), 0.0);
+        assertEquals(0, scale.scaleValue(10), 0.0);
+    }
+}

--- a/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/RasterScaleTest.java
+++ b/gt-elasticsearch-parent/gt-elasticsearch-process/src/test/java/mil/nga/giat/process/elasticsearch/RasterScaleTest.java
@@ -6,10 +6,9 @@ package mil.nga.giat.process.elasticsearch;
 
 import static org.junit.Assert.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
 
 public class RasterScaleTest {
 
@@ -21,17 +20,14 @@ public class RasterScaleTest {
     
     @Test
     public void testRasterScale_emptyRange() throws Exception {
-        List<Float> range = new ArrayList<Float>();
-        RasterScale scale = new RasterScale(range);
+        RasterScale scale = new RasterScale(ImmutableList.of());
         assertFalse(scale.isScaleSet());
     }
     
     @Test
     public void testRasterScale_maxProvided() throws Exception {
         float scaleMax = 10.0f;
-        List<Float> range = new ArrayList<Float>();
-        range.add(scaleMax);
-        RasterScale scale = new RasterScale(range);
+        RasterScale scale = new RasterScale(ImmutableList.of(scaleMax));
         assertTrue(scale.isScaleSet());
         assertEquals(0, scale.getScaleMin(), 0.0);
         assertEquals(scaleMax, scale.getScaleMax(), 0.0);
@@ -41,10 +37,7 @@ public class RasterScaleTest {
     public void testRasterScale_minMaxProvided() throws Exception {
         float scaleMax = 10.0f;
         float scaleMin = 1.0f;
-        List<Float> range = new ArrayList<Float>();
-        range.add(scaleMin);
-        range.add(scaleMax);
-        RasterScale scale = new RasterScale(range);
+        RasterScale scale = new RasterScale(ImmutableList.of(scaleMax, scaleMin));
         assertTrue(scale.isScaleSet());
         assertEquals(scaleMin, scale.getScaleMin(), 0.0);
         assertEquals(scaleMax, scale.getScaleMax(), 0.0);
@@ -54,20 +47,14 @@ public class RasterScaleTest {
     public void testRasterScale_minMaxSame() throws Exception {
         float scaleMax = 10.0f;
         float scaleMin = scaleMax;
-        List<Float> range = new ArrayList<Float>();
-        range.add(scaleMin);
-        range.add(scaleMax);
-        new RasterScale(range);
+        new RasterScale(ImmutableList.of(scaleMax, scaleMin));
     }
     
     @Test
     public void testRasterScale_scaleValue() throws Exception {
         float scaleMax = 10.0f;
         float scaleMin = 0.0f;
-        List<Float> range = new ArrayList<Float>();
-        range.add(scaleMin);
-        range.add(scaleMax);
-        RasterScale scale = new RasterScale(range);
+        RasterScale scale = new RasterScale(ImmutableList.of(scaleMax, scaleMin));
         scale.prepareScale(30);
         scale.prepareScale(20);
         scale.prepareScale(10);
@@ -85,5 +72,14 @@ public class RasterScaleTest {
         assertEquals(30, scale.scaleValue(30), 0.0);
         assertEquals(20, scale.scaleValue(20), 0.0);
         assertEquals(10, scale.scaleValue(10), 0.0);
+    }
+    
+    @Test
+    public void testRasterScale_scaleValue_dataMinAndDataMaxAreTheSame() throws Exception {
+        float scaleMax = 10.0f;
+        float scaleMin = 1.0f;
+        RasterScale scale = new RasterScale(ImmutableList.of(scaleMax, scaleMin));
+        scale.prepareScale(30);
+        assertEquals(10, scale.scaleValue(30), 0.0);
     }
 }


### PR DESCRIPTION
When zoomed out, document counts are rather large. When zoomed in, document counts tend to greatly decrease in size. It is extremely difficult to define a ColorMap that is flexible enough to style raster values between zoom levels. 

This pull request adds an optional parameter `gridStrategyScale` that allows users to provide a scale to solve this problem. The only caveat is that the scalin applies to only a single tile request at a time. If a map is not requesting the WMS layer as a single tile, then the results are meaningless.