### PR TITLE
Handle Elasticsearch GeoJSON circles using interpolation

### DIFF
--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/FilterToElasticHelper.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/FilterToElasticHelper.java
@@ -69,21 +69,28 @@ class FilterToElasticHelper {
     /**
      * Conversion factor from common units to meter
      */
-    protected static final Map<String, Double> UNITS_MAP = new HashMap<String, Double>() {
+    static final Map<String, Double> UNITS_MAP = new HashMap<String, Double>() {
 
         private static final long serialVersionUID = 1L;
 
         {
+            // Metric
+            put("millimeter", 0.001);
+            put("mm", 0.001);
+            put("cm", 0.01);
+            put("m", 1.0);
             put("kilometers", 1000.0);
             put("kilometer", 1000.0);
-            put("mm", 0.001);
-            put("millimeter", 0.001);
+            put("km", 1000.0);
+            // Other
+            put("in", 0.0254);
+            put("ft", 0.3048);
+            put("feet", 0.3048);
+            put("yd", 0.9144);
             put("mi", 1609.344);
             put("miles", 1609.344);
             put("NM", 1852d);
-            put("feet", 0.3048);
-            put("ft", 0.3048);
-            put("in", 0.0254);
+            put("nmi", 1852d);
         }
     };
 

--- a/gt-elasticsearch/src/test/java/mil/nga/giat/data/elasticsearch/ElasticParserUtilTest.java
+++ b/gt-elasticsearch/src/test/java/mil/nga/giat/data/elasticsearch/ElasticParserUtilTest.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import mil.nga.giat.data.elasticsearch.ElasticParserUtil;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +39,7 @@ public class ElasticParserUtilTest {
 
     private GeometryFactory geometryFactory;
 
-    private Map<String,Object> properties;
+    private Map<String, Object> properties;
 
     private Random rand;
 
@@ -58,62 +56,62 @@ public class ElasticParserUtilTest {
 
     @Test
     public void testParseGeoPointPatternForNegatives() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
         final String value = lat + "," + lon;
         final Geometry geom = parserUtil.createGeometry(value);
-        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
     public void testGeoPointPatternForFractions() {
-        final double lat = rand.nextDouble()*2-1;
-        final double lon = rand.nextDouble()*2-1;
+        final double lat = rand.nextDouble() * 2 - 1;
+        final double lon = rand.nextDouble() * 2 - 1;
         final String value = (lat + "," + lon).replace("0.", ".");
         final Geometry geom = parserUtil.createGeometry(value);
-        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
     public void testGeoPointPatternForWholeValues() {
         final Geometry geom = parserUtil.createGeometry("45,90");
-        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(90,45))));
+        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(90, 45))));
     }
 
     @Test
     public void testGeoPointPatternWithSpace() {
         final Geometry geom = parserUtil.createGeometry("45, 90");
-        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(90,45))));
+        assertTrue(geom.equals(geometryFactory.createPoint(new Coordinate(90, 45))));
     }
 
     @Test
     public void testGeoPointAsDoubleProperties() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
         properties.put("lat", lat);
         properties.put("lon", lon);
         final Geometry geometry = parserUtil.createGeometry(properties);
-        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
     public void testGeoPointAsIntegerProperties() {
-        final int lat = rand.nextInt(180)-90;
-        final int lon = rand.nextInt(360)-180;
+        final int lat = rand.nextInt(180) - 90;
+        final int lon = rand.nextInt(360) - 180;
         properties.put("lat", lat);
         properties.put("lon", lon);
         final Geometry geometry = parserUtil.createGeometry(properties);
-        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
     public void testGeoPointAsStringProperties() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
         properties.put("lat", String.valueOf(lat));
         properties.put("lon", String.valueOf(lon));
         final Geometry geometry = parserUtil.createGeometry(properties);
-        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
@@ -121,59 +119,59 @@ public class ElasticParserUtilTest {
         properties.put("lat", true);
         properties.put("lon", true);
         final Geometry geometry = parserUtil.createGeometry(properties);
-        assertTrue(geometry==null);
+        assertTrue(geometry == null);
     }
 
     @Test
     public void testGeoPointAsUnrecognizedProperties() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
         properties.put("latD", lat);
         properties.put("lonD", lon);
         final Geometry geometry = parserUtil.createGeometry(properties);
-        assertTrue(geometry==null);
+        assertTrue(geometry == null);
     }
 
     @Test
     public void testGeoPointAsStringArray() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
-        final Geometry geometry = parserUtil.createGeometry(Arrays.asList(new String[] {
-                String.valueOf(lon),String.valueOf(lat)}));
-        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
+        final Geometry geometry = parserUtil.createGeometry(Arrays.asList(new String[]{
+            String.valueOf(lon), String.valueOf(lat)}));
+        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
     public void testGeoPointAsInvalidArray() {
-        final Geometry geometry = parserUtil.createGeometry(Arrays.asList(new Boolean[] {true,true}));
-        assertTrue(geometry==null);
+        final Geometry geometry = parserUtil.createGeometry(Arrays.asList(new Boolean[]{true, true}));
+        assertTrue(geometry == null);
     }
 
     @Test
     public void testGeoPointAsDoubleArray() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
-        final Geometry geometry = parserUtil.createGeometry(Arrays.asList(new Double[] {lon,lat}));
-        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon,lat))));
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
+        final Geometry geometry = parserUtil.createGeometry(Arrays.asList(new Double[]{lon, lat}));
+        assertTrue(geometry.equals(geometryFactory.createPoint(new Coordinate(lon, lat))));
     }
 
     @Test
     public void testGeoHash() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
         String geohash = GeoHash.encodeHash(lat, lon, 11);
-        final Geometry expected = geometryFactory.createPoint(new Coordinate(lon,lat));
+        final Geometry expected = geometryFactory.createPoint(new Coordinate(lon, lat));
         final Geometry actual = parserUtil.createGeometry(geohash);
         assertEquals(0, expected.distance(actual), 1e-5);
     }
 
     @Test
     public void testInvalidStringGeometry() {
-        final double lat = rand.nextDouble()*90-90;
-        final double lon = rand.nextDouble()*180-180;
-        assertTrue(parserUtil.createGeometry(String.valueOf(lat))==null);
-        assertTrue(parserUtil.createGeometry(lat + "," + lon + "," + 0)==null);
-        assertTrue(parserUtil.createGeometry("x:" + lat + "," + lon)==null);
+        final double lat = rand.nextDouble() * 90 - 90;
+        final double lon = rand.nextDouble() * 180 - 180;
+        assertTrue(parserUtil.createGeometry(String.valueOf(lat)) == null);
+        assertTrue(parserUtil.createGeometry(lat + "," + lon + "," + 0) == null);
+        assertTrue(parserUtil.createGeometry("x:" + lat + "," + lon) == null);
     }
 
     @Test
@@ -185,7 +183,7 @@ public class ElasticParserUtilTest {
     @Test
     public void testGeoShapePointString() throws JsonParseException, JsonMappingException, IOException {
         Point geom = rgb.createRandomPoint();
-        final Map<String,Object> map = new HashMap<>();
+        final Map<String, Object> map = new HashMap<>();
         final List<String> coords = new ArrayList<>();
         coords.add(String.valueOf(geom.getX()));
         coords.add(String.valueOf(geom.getY()));
@@ -204,6 +202,20 @@ public class ElasticParserUtilTest {
     public void testGeoShapePolygon() throws JsonParseException, JsonMappingException, IOException {
         Polygon geom = rgb.createRandomPolygon();
         assertTrue(parserUtil.createGeometry(rgb.toMap(geom)).equalsExact(geom, 1e-9));
+    }
+
+    @Test
+    public void testGeoShapeCircle() throws JsonParseException, JsonMappingException, IOException {
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("type", "circle");
+        inputMap.put("radius", "5nmi");
+        List<String> posList = new ArrayList<>();
+        posList.add("8.0");
+        posList.add("35.0");
+        inputMap.put("coordinates", posList);
+        Geometry geometry = parserUtil.createGeometry(inputMap);
+
+        assertNotNull(geometry);
     }
 
     @Test
@@ -241,14 +253,14 @@ public class ElasticParserUtilTest {
     @Test
     public void testUnrecognizedGeometry() {
         final Geometry geom = parserUtil.createGeometry(3.0);
-        assertTrue(geom==null);
+        assertTrue(geom == null);
     }
 
     @Test
     public void testReadStringField() {
         properties.put("attr", "value");
         List<Object> values = parserUtil.readField(properties, "attr");
-        assertTrue(values.size()==1);
+        assertTrue(values.size() == 1);
         assertTrue(values.get(0).equals("value"));
     }
 
@@ -256,78 +268,117 @@ public class ElasticParserUtilTest {
     public void testReadNumericField() {
         properties.put("attr", 2.3);
         List<Object> values = parserUtil.readField(properties, "attr");
-        assertTrue(values.size()==1);
+        assertTrue(values.size() == 1);
         assertTrue(values.get(0).equals(2.3));
     }
 
     @Test
     public void testReadStringFieldWithConfuser() {
-        properties.put("parent1", new LinkedHashMap<String,Object>());
+        properties.put("parent1", new LinkedHashMap<String, Object>());
         ((Map) properties.get("parent1")).put("attr", "value2");
         properties.put("attr", "value");
-        properties.put("parent2", new LinkedHashMap<String,Object>());
+        properties.put("parent2", new LinkedHashMap<String, Object>());
         ((Map) properties.get("parent2")).put("attr", "value3");
         List<Object> values = parserUtil.readField(properties, "attr");
-        assertTrue(values.size()==1);
+        assertTrue(values.size() == 1);
         assertTrue(values.get(0).equals("value"));
     }
 
     @Test
     public void testReadInnerString() {
-        properties.put("parent", new LinkedHashMap<String,Object>());
+        properties.put("parent", new LinkedHashMap<String, Object>());
         ((Map) properties.get("parent")).put("attr", "value");
         List<Object> values = parserUtil.readField(properties, "parent.attr");
-        assertTrue(values.size()==1);
+        assertTrue(values.size() == 1);
         assertTrue(values.get(0).equals("value"));
     }
 
     @Test
     public void testReadInnerStringArray() {
-        properties.put("parent", new LinkedHashMap<String,Object>());
-        ((Map) properties.get("parent")).put("attr", Arrays.asList(new String[] {"value1", "value2"}));
+        properties.put("parent", new LinkedHashMap<String, Object>());
+        ((Map) properties.get("parent")).put("attr", Arrays.asList(new String[]{"value1", "value2"}));
         List<Object> values = parserUtil.readField(properties, "parent.attr");
-        assertTrue(values.size()==2);
+        assertTrue(values.size() == 2);
         assertTrue(values.get(0).equals("value1"));
         assertTrue(values.get(1).equals("value2"));
     }
 
     @Test
     public void testReadStringFromObjectArray() {
-        properties.put("parent", new ArrayList<Map<String,Object>>());
-        ((List)properties.get("parent")).add(new LinkedHashMap<String,Object>());
-        ((Map) ((List)properties.get("parent")).get(0)).put("attr", "value1");
-        ((List)properties.get("parent")).add(new LinkedHashMap<String,Object>());
-        ((Map) ((List)properties.get("parent")).get(1)).put("attr", "value2");
+        properties.put("parent", new ArrayList<Map<String, Object>>());
+        ((List) properties.get("parent")).add(new LinkedHashMap<String, Object>());
+        ((Map) ((List) properties.get("parent")).get(0)).put("attr", "value1");
+        ((List) properties.get("parent")).add(new LinkedHashMap<String, Object>());
+        ((Map) ((List) properties.get("parent")).get(1)).put("attr", "value2");
         List<Object> values = parserUtil.readField(properties, "parent.attr");
-        assertTrue(values.size()==2);
+        assertTrue(values.size() == 2);
         assertTrue(values.get(0).equals("value1"));
         assertTrue(values.get(1).equals("value2"));
     }
 
     @Test
     public void testReadStringFromObjectArrayOnceRemoved() {
-        properties.put("parent", new ArrayList<Map<String,Object>>());
-        ((List)properties.get("parent")).add(new LinkedHashMap<String,Object>());
-        ((Map) ((List)properties.get("parent")).get(0)).put("child", new LinkedHashMap<String,Object>());
-        ((Map)((Map) ((List)properties.get("parent")).get(0)).get("child")).put("attr", "value1");
-        ((List)properties.get("parent")).add(new LinkedHashMap<String,Object>());
-        ((Map) ((List)properties.get("parent")).get(1)).put("child", new LinkedHashMap<String,Object>());
-        ((Map)((Map) ((List)properties.get("parent")).get(1)).get("child")).put("attr", "value2");
+        properties.put("parent", new ArrayList<Map<String, Object>>());
+        ((List) properties.get("parent")).add(new LinkedHashMap<String, Object>());
+        ((Map) ((List) properties.get("parent")).get(0)).put("child", new LinkedHashMap<String, Object>());
+        ((Map) ((Map) ((List) properties.get("parent")).get(0)).get("child")).put("attr", "value1");
+        ((List) properties.get("parent")).add(new LinkedHashMap<String, Object>());
+        ((Map) ((List) properties.get("parent")).get(1)).put("child", new LinkedHashMap<String, Object>());
+        ((Map) ((Map) ((List) properties.get("parent")).get(1)).get("child")).put("attr", "value2");
         List<Object> values = parserUtil.readField(properties, "parent.child.attr");
-        assertTrue(values.size()==2);
+        assertTrue(values.size() == 2);
         assertTrue(values.get(0).equals("value1"));
         assertTrue(values.get(1).equals("value2"));
     }
 
     @Test
     public void testReadMapField() {
-        final Map<String,Object> map = new LinkedHashMap<String,Object>();
+        final Map<String, Object> map = new LinkedHashMap<String, Object>();
         properties.put("attr", map);
         map.put("attr2", "value2");
         map.put("attr3", "value3");
         List<Object> values = parserUtil.readField(properties, "attr");
-        assertTrue(values.size()==1);
+        assertTrue(values.size() == 1);
         assertTrue(values.get(0).equals(map));
     }
 
+    @Test
+    public void testConvertToMeters() {
+        double distance = ElasticParserUtil.convertToMeters("1.2mm");
+        assertEquals(0.0012, distance, 0.0000000001);
+        distance = ElasticParserUtil.convertToMeters("1.2");
+        assertEquals(1.2, distance, 0.0000000001);
+        distance = ElasticParserUtil.convertToMeters("12");
+        assertEquals(12.0, distance, 0.0000000001);
+        distance = ElasticParserUtil.convertToMeters("0.12cm");
+        assertEquals(0.0012, distance, 0.0000000001);
+        try {
+            distance = ElasticParserUtil.convertToMeters("999xyz");
+            fail("Shouldn't get here");
+        }
+        catch(IllegalArgumentException iae) {
+            
+        }
+         try {
+            distance = ElasticParserUtil.convertToMeters("mm1.2");
+            fail("Shouldn't get here");
+        }
+        catch(IllegalArgumentException iae) {
+            
+        }
+        try {
+            distance = ElasticParserUtil.convertToMeters(".2");
+            fail("Shouldn't get here");
+        }
+        catch(IllegalArgumentException iae) {
+            
+        }
+        try {
+            distance = ElasticParserUtil.convertToMeters(".2m");
+            fail("Shouldn't get here");
+        }
+        catch(IllegalArgumentException iae) {
+            
+        }
+    }
 }


### PR DESCRIPTION
Proposed code to be able to render Elasticsearch GeoJSON circle geometry in GeoServer. The interpolation angular interval is varied according to the circumference of the circle (in ellipsoid surface units as opposed to pixels) and kept between upper and lower bounds.

An example output of  NOTAMs over Cyprus is shown below. Note that the circles are displayed as 'sort-of' ellipses due to the latitude.
![screenshot from 2018-04-04 14-16-36](https://user-images.githubusercontent.com/6906992/38309942-2df7ffbe-3813-11e8-8eec-dbbcf4ff9549.png)
