### PR TITLE
Allow clients to set aggregation precision

### DIFF
--- a/gs-web-elasticsearch/doc/index.rst
+++ b/gs-web-elasticsearch/doc/index.rst
@@ -295,7 +295,7 @@ Aggregation WFS features will include a single attribute, ``_aggregation``, cont
 Geohash grid aggregations
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Geohash grid aggregation support includes dynamic precision updating and a custom rendering transformation for visualization. Geohash grid aggregation precision is updated dynamically to approximate the specified ``grid_size`` based on current bbox extent and the additional ``grid_threshold`` parameter as described above.
+Geohash grid aggregation support includes dynamic precision updating and a custom rendering transformation for visualization. Geohash grid aggregation precision is updated dynamically to approximate the specified ``grid_size`` based on current bbox extent and the additional ``grid_threshold`` parameter as described above. If a ``precision`` value is present in the aggregation defined in ``viewparams``, however, that value will be used instead of the dynamic value.
 
 Geohash grid aggregation visualization is supported in WMS requests through a custom rendering transformation, ``vec:GeoHashGrid``, which translates aggregation response data into a raster for display. By default raster values correspond to the aggregation bucket ``doc_count``. The following shows an example GeoServer style that uses the GeoHashGrid rendering transformation::
 

--- a/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/GeohashUtil.java
+++ b/gt-elasticsearch/src/main/java/mil/nga/giat/data/elasticsearch/GeohashUtil.java
@@ -26,8 +26,12 @@ class GeohashUtil {
     }
 
     public static void updateGridAggregationPrecision(Map<String,Map<String,Map<String,Object>>> aggregations, int precision) {
-        aggregations.values().stream().filter(a -> a.containsKey("geohash_grid")).forEach(a ->
-                a.get("geohash_grid").put("precision", precision));
+        aggregations.values().stream().filter(a -> a.containsKey("geohash_grid")).forEach(a -> {
+            Map<String, Object> geohashGrid = a.get("geohash_grid");
+            if (!geohashGrid.containsKey("precision")) {
+                geohashGrid.put("precision", precision);
+            }
+        });
     }
 
 }

--- a/gt-elasticsearch/src/test/java/mil/nga/giat/data/elasticsearch/GeohashUtilTest.java
+++ b/gt-elasticsearch/src/test/java/mil/nga/giat/data/elasticsearch/GeohashUtilTest.java
@@ -31,8 +31,19 @@ public class GeohashUtilTest {
     }
 
     @Test
-    public void updatePrecision() {
-        final Map<String, Object> geohashGridAgg = new HashMap<>(ImmutableMap.of("field", "name", "precision", 0));
+    public void doNotUpdatePrecisionIfAlreadyDefined() {
+        final Map<String, Object> geohashGridAgg = new HashMap<>(ImmutableMap.of("field", "name", "precision", 3));
+        final Map<String,Map<String,Map<String,Object>>> aggregations;
+        aggregations = ImmutableMap.of("first",ImmutableMap.of("geohash_grid",geohashGridAgg));
+        final Map<String,Object> expected = ImmutableMap.of("first",
+                ImmutableMap.of("geohash_grid",ImmutableMap.of("field","name","precision",3)));
+        GeohashUtil.updateGridAggregationPrecision(aggregations, 2);
+        assertEquals(expected, aggregations);
+    }
+
+    @Test
+    public void updatePrecisionIfNotDefined() {
+        final Map<String, Object> geohashGridAgg = new HashMap<>(ImmutableMap.of("field", "name"));
         final Map<String,Map<String,Map<String,Object>>> aggregations;
         aggregations = ImmutableMap.of("first",ImmutableMap.of("geohash_grid",geohashGridAgg));
         final Map<String,Object> expected = ImmutableMap.of("first",


### PR DESCRIPTION
Currently if a client passes a precision value in an aggregation, it is overridden by the precision computed in GeohashUtil.  For some clients, it is desirable to determine the precision based on client state, for example when using a single tile layer, determining precision as a function of map zoom and viewport bounds.  This change simply avoids updating the precision on the aggregation if one is already present in the request.