### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ cache:
   - "$HOME/.m2"
 install:
 - mvn --version
-- travis_retry mvn install -DskipTests=true -Dskip.integration.tests=true -B -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -Des.test.version=${ES_VERSION} ${ARGS}
+- mvn install -DskipTests=true -Dskip.integration.tests=true -B -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -Des.test.version=${ES_VERSION} ${ARGS}
 script:
 - sudo sysctl -w vm.max_map_count=262144
-- travis_retry mvn verify -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -Des.test.version=${ES_VERSION} ${ARGS}
+- mvn verify -Dgeotools.version=${GEOTOOLS_VERSION} -Dgeoserver.version=${GEOSERVER_VERSION} -Des.test.version=${ES_VERSION} ${ARGS}
 after_success:
 - mvn coveralls:report
 before_deploy:


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
